### PR TITLE
precompile QML

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Priority: extra
 Maintainer: Merlijn Wajer <merlijn@wizzup.org>
 Build-Depends: debhelper (>= 10),
     qtbase5-dev,
+    qt5-default,
     ccache,
     cmake,
     libx11-dev,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,12 +15,12 @@ file(GLOB SOURCE_FILES
         "models/*.cpp"
         )
 
-find_package(Qt5 REQUIRED COMPONENTS Core Widgets Gui Network Svg Xml Quick QuickWidgets Qml QuickControls2)
+find_package(Qt5 REQUIRED COMPONENTS Core Widgets Gui Network Svg Xml Quick QuickWidgets Qml QuickControls2 QuickCompiler)
 if(MAEMO)
     find_package(Qt5 REQUIRED COMPONENTS Maemo5)
 endif()
 
-qt5_add_resources(RESOURCES
+qtquick_compiler_add_resources(RESOURCES
         assets.qrc
         qml/components/qml_components.qrc
         qml/chat/chatty/chatty.qrc
@@ -29,7 +29,7 @@ qt5_add_resources(RESOURCES
         )
 
 if(NOT MAEMO)
-    qt5_add_resources(RESOURCES assets_localdev.qrc)
+    qtquick_compiler_add_resources(RESOURCES assets_localdev.qrc)
 endif()
 
 set(EXECUTABLE_FLAG)


### PR DESCRIPTION
fixes #5 

Requires:

```
ln -s /usr/share/qtchooser/qt5-x86_64-linux-gnu.conf /usr/share/qtchooser/default.conf
```

@MerlijnWajer 