### PR TITLE
Notifications

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+conversations (0.5.1) unstable; urgency=medium
+
+  * Uses /velnias75/libnotify-qt, modified/updated to work on Leste
+  * Notifications are only shown when the app is in the background
+  * Clicking on a notification opens the relevant chat window
+  * Dismissing a notification does nothing
+  * Enable/disable notifications via settings
+  * Does not spam notifications each message; just one notification per individual sender
+
+ -- Sander <sander@kroket.io>  Wed, 26 Okt 2023 01:05:14 +0200
+
 conversations (0.5) unstable; urgency=medium
 
   * general: Introduced QSharedPointer while passing ChatMessage around the codebase. Easier than worrying about raw pointer ownership. This also 'cleans up' some function signatures to make it more readable.
@@ -14,6 +25,8 @@ conversations (0.5) unstable; urgency=medium
   * search: search results overlapping with the search header
   * search: change Text {} to Components.PlainText{} for security reasons (richtext)
   * search: fix searching through multiple (all) protocols
+
+ -- Sander <sander@kroket.io>  Thu, 8 Sep 2022 15:10:12 +0200
 
 conversations (0.4.3) unstable; urgency=medium
 

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,8 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@
+	dh $@ --buildsystem=cmake
+
+override_dh_auto_configure:
+	dh_auto_configure -- \
+	-DCMAKE_BUILD_TYPE=Release

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,8 @@ file(GLOB SOURCE_FILES
         "lib/*.cpp"
         "models/*.h"
         "models/*.cpp"
+        "lib/libnotify-qt/*.h"
+        "lib/libnotify-qt/*.cpp"
         )
 
 find_package(Qt5 REQUIRED COMPONENTS Core Widgets Gui Network DBus Svg Xml Quick QuickWidgets Qml QuickControls2 QuickCompiler)

--- a/src/chatwindow.cpp
+++ b/src/chatwindow.cpp
@@ -125,7 +125,7 @@ void ChatWindow::onChatPreReady() {
   emit chatPostReady();
 }
 
-void ChatWindow::onDatabaseAddition(ChatMessage *msg) {
+void ChatWindow::onDatabaseAddition(const QSharedPointer<ChatMessage> &msg) {
   if(m_chatMessage->local_uid() == msg->local_uid() && m_chatMessage->remote_uid() == msg->remote_uid()) {
     this->chatModel->appendMessage(msg);
   }
@@ -159,6 +159,7 @@ bool ChatWindow::eventFilter(QObject *watched, QEvent *event) {
 
 void ChatWindow::closeEvent(QCloseEvent *event) {
   this->chatModel->clear();
+  m_chatMessage.clear();
   emit closed();
   QWidget::closeEvent(event);
 }

--- a/src/chatwindow.h
+++ b/src/chatwindow.h
@@ -36,7 +36,7 @@ public:
     ChatModel *chatModel;
 
 public slots:
-  void onDatabaseAddition(ChatMessage *msg);
+  void onDatabaseAddition(const QSharedPointer<ChatMessage> &msg);
 
 private slots:
     void onChatPreReady();

--- a/src/conversations.h
+++ b/src/conversations.h
@@ -10,6 +10,7 @@
 #include "lib/config.h"
 #include "lib/ipc.h"
 #include "lib/tp.h"
+#include "lib/libnotify-qt/Notification.h"
 #include "models/ChatModel.h"
 #include "models/ChatMessage.h"
 #include "models/OverviewServiceModel.h"
@@ -30,6 +31,7 @@ public:
     ~Conversations() override;
     bool isDebug = false;
     bool isMaemo = false;
+    bool isBackground = false;
 
     QCommandLineParser *cmdargs;
     IPC *ipc;
@@ -47,6 +49,9 @@ public:
     OverviewServiceModel *overviewServiceModel;
     Telepathy *telepathy;
 
+    // keep track of previous libnotify broadcasts to prevent notification spam
+    QMap<QString, QSharedPointer<ChatMessage>> notificationMap;  // remote_uid, context
+
     void setWindowTitle(const QString &title);
     Q_INVOKABLE QString ossoIconLookup(const QString &filename); // /usr/share/icons/hicolor/48x48/hildon/
 
@@ -61,13 +66,15 @@ signals:
     void hideApplication();
     void openChatWindow(const QString &remote_uid);
     void reloadOverview();
-    void databaseAddition(ChatMessage *msg);
+    void databaseAddition(const QSharedPointer<ChatMessage> &msg);
+    void notificationClicked(const QSharedPointer<ChatMessage> &msg);
 
 public slots:
     void onSendOutgoingMessage(const QString &local_uid, const QString &remote_uid, const QString &message);
     void onTextScalingChanged();
     void onIPCReceived(const QString &cmd);
-    void onDatabaseAddition(ChatMessage *msg);
+    void onDatabaseAddition(const QSharedPointer<ChatMessage> &msg);
+    void onNotificationClicked(const QSharedPointer<ChatMessage> &msg);
 
 private:
     float m_textScaling = 1.0;

--- a/src/lib/config.cpp
+++ b/src/lib/config.cpp
@@ -18,6 +18,7 @@ static const QHash<ConfigKeys::ConfigKey, ConfigDirective> configStrings = {
   {ConfigKeys::MaemoTest,{QS("MaemoTest"), ""}},
   {ConfigKeys::ChatTheme,{QS("ChatTheme"), "whatsthat"}},
   {ConfigKeys::TextScaling,{QS("TextScaling"), 1.0}},
+  {ConfigKeys::EnableNotifications,{QS("EnableNotifications"), true}},
   {ConfigKeys::EnterKeySendsChat,{QS("EnterKeySendsChat"), false}}
 };
 

--- a/src/lib/config.h
+++ b/src/lib/config.h
@@ -14,6 +14,7 @@ namespace ConfigKeys
         MaemoTest,
         ChatTheme,
         TextScaling,
+        EnableNotifications,
         EnterKeySendsChat
     };
     Q_ENUM_NS(ConfigKey)

--- a/src/lib/libnotify-qt/Notification.cpp
+++ b/src/lib/libnotify-qt/Notification.cpp
@@ -1,0 +1,248 @@
+/* libnotify-qt - library for sending notifications implemented in Qt
+ * Copyright (C) 2010-2011 Vojtech Drbohlav <vojta.d@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Notification.h"
+
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDebug>
+
+#include "OrgFreedesktopNotificationsInterface.h"
+
+bool Notification::s_isInitted = false;
+QString Notification::s_appName;
+org::freedesktop::Notifications * Notification::s_notifications = 0;
+
+bool Notification::init(const QString & appName)
+{
+	if(!QDBusConnection::sessionBus().isConnected())
+		return false;
+
+	s_notifications = new org::freedesktop::Notifications("org.freedesktop.Notifications",
+														  "/org/freedesktop/Notifications",
+														  QDBusConnection::sessionBus());
+
+	s_appName = appName;
+	s_isInitted = s_notifications->isValid();
+	return s_isInitted;
+}
+
+void Notification::uninit()
+{
+	s_isInitted = false;
+
+	delete s_notifications;
+}
+
+bool Notification::isInitted()
+{
+	return s_isInitted;
+}
+
+const QString & Notification::getAppName()
+{
+	return s_appName;
+}
+
+QStringList Notification::getServerCaps()
+{
+	QDBusPendingReply<QStringList> reply = s_notifications->getCapabilities();
+	reply.waitForFinished();
+
+	if(reply.isValid())
+	{
+		return reply.argumentAt(0).toStringList();
+	}
+
+	return QStringList();
+}
+
+bool Notification::getServerInfo(QString & name, QString & vendor, QString & version)
+{
+	QDBusPendingReply<QString, QString, QString> reply = s_notifications->getServerInformation();
+	reply.waitForFinished();
+
+	if(reply.isValid())
+	{
+		name = reply.argumentAt(SERVER_INFO_NAME).toString();
+		vendor = reply.argumentAt(SERVER_INFO_VENDOR).toString();
+		version = reply.argumentAt(SERVER_INFO_VERSION).toString();
+		return true;
+	}
+
+	return false;
+}
+
+Notification::Notification(const QSharedPointer<ChatMessage> &msg, const QString &summary, const QString &body, const QString &iconName, int timeout, QObject * parent) :
+	QObject(parent),
+	m_id(0),
+	m_summary(summary),
+	m_body(body),
+  m_context(msg),
+	m_iconName(iconName),
+	m_timeout(timeout),
+	m_autoDelete(true)
+{
+	setUrgency(NOTIFICATION_URGENCY_NORMAL);
+
+	// TODO: i should do this somehow in org::freedesktop::Notifications imho
+//	QDBusConnection::sessionBus().connect(QString(), QString(), org::freedesktop::Notifications::staticInterfaceName(),
+//										  "NotificationClosed", this, SLOT(onNotificationClosed(quint32, quint32)));
+
+  QDBusConnection::sessionBus().connect(QString(), QString(), org::freedesktop::Notifications::staticInterfaceName(),
+										  "NotificationClosed", this, SLOT(onNotificationClosed(quint32)));
+
+	QDBusConnection::sessionBus().connect(QString(), QString(), org::freedesktop::Notifications::staticInterfaceName(),
+										  "ActionInvoked", this, SLOT(onActionInvoked(quint32,QString)));
+}
+
+Notification::~Notification()
+{
+	disconnect(s_notifications);
+}
+
+bool Notification::show()
+{
+	QDBusPendingReply<quint32> reply = s_notifications->notify(getAppName(), m_id, m_iconName, m_summary, m_body,
+															   m_actions, m_hints, m_timeout);
+	if(m_id == 0)
+	{
+		reply.waitForFinished();
+		if(!reply.isValid())
+			return false;
+
+		m_id = reply.argumentAt(0).toInt();
+	}
+
+	return true;
+}
+
+void Notification::setSummary(const QString & summary)
+{
+	m_summary = summary;
+}
+
+void Notification::setBody(const QString & body)
+{
+	m_body = body;
+}
+
+void Notification::setIconName(const QString & iconName)
+{
+	m_iconName = iconName;
+}
+
+void Notification::setTimeout(qint32 timeout)
+{
+	m_timeout = timeout;
+}
+
+void Notification::setUrgency(NotificationUrgency urgency)
+{
+	setHintByte("urgency", urgency);
+}
+
+void Notification::setCategory(const QString & category)
+{
+	setHintString("category", category);
+}
+
+/*void Notification::setIconFromPixmap(const QPixmap & pixmap)
+{
+	setHintByteArray("image_data",pixmap.t);
+}*/
+
+void Notification::setLocation(qint32 x, qint32 y)
+{
+	setHintInt32("x", x);
+	setHintInt32("y", y);
+}
+
+void Notification::setHint(const QString & key, const QVariant & value)
+{
+	m_hints.insert(key, value);
+}
+
+void Notification::setHintInt32(const QString & key, qint32 value)
+{
+	m_hints.insert(key, value);
+}
+
+void Notification::setHintDouble(const QString & key, double value)
+{
+	m_hints.insert(key, value);
+}
+
+void Notification::setHintString(const QString & key, const QString & value)
+{
+	m_hints.insert(key, value);
+}
+
+void Notification::setHintByte(const QString & key, char value)
+{
+    setHintByteArray(key, QByteArray(1, value));
+}
+
+void Notification::setHintByteArray(const QString & key, const QByteArray & value)
+{
+	m_hints.insert(key, value);
+}
+
+void Notification::clearHints()
+{
+	m_hints.clear();
+}
+
+void Notification::addAction(const QString & actionKey, const QString & label)
+{
+	m_actions << actionKey << label;
+}
+
+void Notification::clearActions()
+{
+	m_actions.clear();
+}
+
+bool Notification::close()
+{
+	QDBusPendingReply<> reply = s_notifications->closeNotification(m_id);
+	reply.waitForFinished();
+	return reply.isValid();
+}
+
+bool Notification::autoDelete() const
+{
+	return m_autoDelete;
+}
+
+void Notification::setAutoDelete(bool autoDelete)
+{
+	m_autoDelete = autoDelete;
+}
+
+void Notification::onNotificationClosed(quint32 id) {
+	if(m_id == id && m_autoDelete) {
+    this->deleteLater();
+	}
+}
+
+void Notification::onActionInvoked(quint32 id, const QString & actionKey) {
+  // actionKey == "default" on notification click
+	if(m_id == id) {
+		emit clicked(m_context);
+	}
+}

--- a/src/lib/libnotify-qt/Notification.h
+++ b/src/lib/libnotify-qt/Notification.h
@@ -1,0 +1,128 @@
+/* libnotify-qt - library for sending notifications implemented in Qt
+ * Copyright (C) 2010-2011 Vojtech Drbohlav <vojta.d@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef NOTIFICATION_H
+#define NOTIFICATION_H
+
+#include <QList>
+#include <QObject>
+#include <QStringList>
+#include <QVariantMap>
+#include "models/ChatMessage.h"
+
+enum ServerInfo
+{
+	SERVER_INFO_NAME = 0,
+	SERVER_INFO_VENDOR,
+	SERVER_INFO_VERSION
+};
+
+enum NotificationUrgency
+{
+	NOTIFICATION_URGENCY_LOW,
+	NOTIFICATION_URGENCY_NORMAL,
+	NOTIFICATION_URGENCY_CRITICAL
+};
+
+class QDBusInterface;
+class OrgFreedesktopNotificationsInterface;
+
+namespace org
+{
+	namespace freedesktop
+	{
+		typedef OrgFreedesktopNotificationsInterface Notifications;
+	}
+}
+
+class Q_DECL_EXPORT Notification : public QObject
+{
+	Q_OBJECT
+
+	typedef QList<Notification *> NotificationList;
+
+	public:
+		static bool init(const QString & appName);
+		static void uninit();
+		static bool isInitted();
+
+		static const QString & getAppName();
+		static QStringList getServerCaps();
+		static bool getServerInfo(QString & name, QString & vendor, QString & version);
+
+		Notification(const QSharedPointer<ChatMessage> &msg, const QString &summary, const QString &body = QString(),
+					 const QString &iconName = QString(), qint32 timeout = 5000, QObject *parent = 0);
+		~Notification();
+
+		bool show();
+
+		void setSummary(const QString & summary);
+		void setBody(const QString & body);
+		void setIconName(const QString & iconName);
+		void setTimeout(qint32 timeout);
+
+		void setUrgency(NotificationUrgency urgency);
+		void setCategory(const QString & category);
+		//void setIconFromPixmap(const QPixmap & pixmap);
+		void setLocation(qint32 x, qint32 y);
+
+		void setHint(const QString & key, const QVariant & value);
+		void setHintInt32(const QString & key, qint32 value);
+		void setHintDouble(const QString & key, double value);
+		void setHintString(const QString & key, const QString & value);
+		void setHintByte(const QString & key, char value);
+		void setHintByteArray(const QString & key, const QByteArray & value);
+		void clearHints();
+
+		void addAction(const QString & actionKey, const QString & label);
+		void clearActions();
+
+		bool close();
+
+		bool autoDelete() const;
+		void setAutoDelete(bool autoDelete);
+
+	private slots:
+		void onNotificationClosed(quint32 id);
+		void onActionInvoked(quint32 id, const QString & actionKey);
+
+	private:
+		static void addNotification(Notification * n);
+		static void removeNotification(Notification * n);
+
+	private:
+		static bool s_isInitted;
+		static QString s_appName;
+		static org::freedesktop::Notifications * s_notifications;
+
+		quint32 m_id;
+		QString m_summary;
+		QString m_body;
+		QString m_iconName;
+		qint32 m_timeout;
+    QSharedPointer<ChatMessage> m_context;
+		QStringList m_actions;
+		QVariantMap m_hints;
+
+		bool m_autoDelete;
+
+	signals:
+		void closed(quint32 reason);
+		void clicked(const QSharedPointer<ChatMessage> &msg);
+};
+
+#endif // NOTIFICATION_H

--- a/src/lib/libnotify-qt/OrgFreedesktopNotificationsInterface.cpp
+++ b/src/lib/libnotify-qt/OrgFreedesktopNotificationsInterface.cpp
@@ -1,0 +1,56 @@
+/* libnotify-qt - library for sending notifications implemented in Qt
+ * Copyright (C) 2010-2011 Vojtech Drbohlav <vojta.d@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "OrgFreedesktopNotificationsInterface.h"
+
+OrgFreedesktopNotificationsInterface::OrgFreedesktopNotificationsInterface(const QString & service,
+																		   const QString & path,
+																		   const QDBusConnection & connection,
+																		   QObject * parent) :
+	QDBusAbstractInterface(service, path, staticInterfaceName(), connection, parent)
+{
+}
+
+OrgFreedesktopNotificationsInterface::~OrgFreedesktopNotificationsInterface()
+{
+}
+
+QDBusPendingReply<QStringList> OrgFreedesktopNotificationsInterface::getCapabilities()
+{
+	return asyncCall("GetCapabilities");
+}
+
+QDBusPendingReply<quint32> OrgFreedesktopNotificationsInterface::notify(const QString & appName, quint32 replacesId,
+																		const QString & appIcon,
+																		const QString & summary, const QString & body,
+																		const QStringList & actions,
+																		const QVariantMap & hints,
+																		qint32 timeout)
+{
+	return asyncCall("Notify", appName, replacesId, appIcon, summary, body, actions, hints, timeout);
+}
+
+QDBusPendingReply<> OrgFreedesktopNotificationsInterface::closeNotification(quint32 id)
+{
+	return asyncCall("CloseNotification", id);
+}
+
+QDBusPendingReply<QString, QString, QString> OrgFreedesktopNotificationsInterface::getServerInformation()
+{
+	return asyncCall("GetServerInformation");
+}
+

--- a/src/lib/libnotify-qt/OrgFreedesktopNotificationsInterface.h
+++ b/src/lib/libnotify-qt/OrgFreedesktopNotificationsInterface.h
@@ -1,0 +1,60 @@
+/* libnotify-qt - library for sending notifications implemented in Qt
+ * Copyright (C) 2010-2011 Vojtech Drbohlav <vojta.d@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ORGFREEDESKTOPNOTIFICATIONSINTERFACE_H
+#define ORGFREEDESKTOPNOTIFICATIONSINTERFACE_H
+
+#include <QDBusAbstractInterface>
+#include <QDBusPendingReply>
+
+class OrgFreedesktopNotificationsInterface : public QDBusAbstractInterface
+{
+	Q_OBJECT
+
+	public:
+		OrgFreedesktopNotificationsInterface(const QString & service, const QString & path,
+											 const QDBusConnection & connection, QObject * parent = 0);
+		~OrgFreedesktopNotificationsInterface();
+
+		static inline const char * staticInterfaceName()
+		{
+			return "org.freedesktop.Notifications";
+		}
+
+	public slots:
+		QDBusPendingReply<QStringList> getCapabilities();
+		QDBusPendingReply<quint32> notify(const QString & appName, quint32 replacesId, const QString & appIcon,
+										  const QString & summary, const QString & body,
+										  const QStringList & actions, const QVariantMap & hints,
+										  qint32 timeout);
+		QDBusPendingReply<> closeNotification(quint32 id);
+		QDBusPendingReply<QString, QString, QString> getServerInformation();
+
+	/*signals:
+		void notificationClosed(quint32 id, quint32 reason);
+		void actionInvoked(quint32 id, const QString & actionKey);*/
+};
+
+namespace org
+{
+	namespace freedesktop
+	{
+		typedef OrgFreedesktopNotificationsInterface Notifications;
+	}
+}
+
+#endif // ORGFREEDESKTOPNOTIFICATIONSINTERFACE_H

--- a/src/lib/rtcom.cpp
+++ b/src/lib/rtcom.cpp
@@ -116,12 +116,14 @@ QList<QString> rtcomGetLocalUids() {
     return protocols;
   }
 
-  for(auto *item: rtcomIterateResults(query_struct)) {
+  auto items = rtcomIterateResults(query_struct);
+  for(auto &item: items) {
     auto local_uid = item->local_uid();
     if(local_uid.count("/") != 2) continue;
     auto protocol = local_uid.split("/").at(1);
     protocols << protocol;
   }
+  qDeleteAll(items);
 
   g_object_unref(query_struct->query);
   delete query_struct;

--- a/src/lib/tp.h
+++ b/src/lib/tp.h
@@ -93,7 +93,7 @@ public:
     QString protocolName() const { return m_protocol_name; }
 
 signals:
-    void databaseAddition(ChatMessage *msg);
+    void databaseAddition(const QSharedPointer<ChatMessage> &msg);
 
 public slots:
     void sendMessage(const QString &local_uid, const QString &remote_uid, const QString &message);
@@ -132,12 +132,12 @@ public:
     QList<TelepathyAccount*> accounts;
 
 signals:
-    void databaseAddition(ChatMessage *msg);
+    void databaseAddition(const QSharedPointer<ChatMessage> &msg);
     void accountManagerReady();
 
 public slots:
     void sendMessage(const QString &local_uid, const QString &remote_uid, const QString &message);
-    void onDatabaseAddition(ChatMessage *msg);
+    void onDatabaseAddition(const QSharedPointer<ChatMessage> &msg);
 
 private slots:
     void onAccountManagerReady(Tp::PendingOperation *op);

--- a/src/lib/utils.cpp
+++ b/src/lib/utils.cpp
@@ -5,6 +5,7 @@
 
 #include "utils.h"
 #include "lib/config.h"
+#include "models/ChatMessage.h"
 
 bool Utils::fileExists(const QString &path) {
     QFileInfo check_file(path);
@@ -99,4 +100,16 @@ QMap<QString, QLocale> Utils::localeCache = {};
 double Utils::roundUp(double value, int decimal_places) {
     const double multiplier = std::pow(10.0, decimal_places);
     return std::ceil(value * multiplier) / multiplier;
+}
+Notification* Utils::notification(QString title, QString message, const QSharedPointer<ChatMessage> &msg) {
+    auto *notification = new Notification(msg, title, message, "general_sms", 0);  // auto-deleted after notification click/close
+    notification->show();
+    return notification;
+}
+
+QString Utils::protocolToRTCOMServiceID(const QString &protocol) {
+  if(protocol.contains("sms") || protocol.contains("tel") || protocol.contains("ofono")) {
+    return "RTCOM_EL_SERVICE_SMS";
+  }
+  return "RTCOM_EL_SERVICE_CHAT";
 }

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -8,6 +8,8 @@
 #include <QApplication>
 #include <QTextCharFormat>
 
+#include "lib/libnotify-qt/Notification.h"
+
 class Utils
 {
 
@@ -25,6 +27,8 @@ public:
     static QString formatBytes(quint64 bytes);
     static double roundUp(double value, int decimal_places);
     static QMap<QString, QLocale> localeCache;
+    static Notification* notification(QString title, QString message, const QSharedPointer<ChatMessage> &msg);
+    static QString protocolToRTCOMServiceID(const QString &protocol);
 };
 
 class Conversations;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -22,6 +22,7 @@
 #include "searchwindow.h"
 #include "settings.h"
 #include "lib/config.h"
+#include "lib/libnotify-qt/Notification.h"
 
 namespace Ui {
     class MainWindow;
@@ -56,6 +57,7 @@ public slots:
     void onHideApplication();
     void onChatWindowClosed();
     void onTPAccountManagerReady();
+    void onNotificationClicked(const QSharedPointer<ChatMessage> &msg);
 
 signals:
     void requestOverviewSearchWindow();

--- a/src/models/ChatMessage.cpp
+++ b/src/models/ChatMessage.cpp
@@ -37,6 +37,14 @@ QString ChatMessage::remote_uid() const { return m_remote_uid; }
 QString ChatMessage::remote_name() const { return m_remote_name; }
 QString ChatMessage::remote_ebook_uid() const { return m_remote_ebook_uid; }
 QString ChatMessage::text() const { return m_text; }
+QString ChatMessage::textSnippet() const {
+  auto max_length = 32;
+  if(m_text.length() >= max_length) {
+    QString snippet = m_text.mid(0, max_length) + "...";
+    return snippet;
+  }
+  return m_text;
+}
 QString ChatMessage::icon_name() const { return m_icon_name; }
 int ChatMessage::count() const { return m_count; }
 QString ChatMessage::group_title() const { return m_group_title; }

--- a/src/models/ChatMessage.h
+++ b/src/models/ChatMessage.h
@@ -25,6 +25,7 @@ public:
     QString remote_name() const;
     QString remote_ebook_uid() const;
     QString text() const;
+    QString textSnippet() const;
     QString icon_name() const;
     QDateTime date() const;
     int count() const;

--- a/src/models/ChatModel.cpp
+++ b/src/models/ChatModel.cpp
@@ -15,15 +15,17 @@ ChatModel::ChatModel(QObject *parent)
 
 void ChatModel::prependMessage(ChatMessage *message) {
   QSharedPointer<ChatMessage> ptr(message);
+}
 
+void ChatModel::prependMessage(const QSharedPointer<ChatMessage> &message) {
   if(!chats.isEmpty()) {
     auto n = chats.at(0);
-    ptr->next = n;
-    n->previous = ptr;
+    message->next = n;
+    n->previous = message;
   }
 
   beginInsertRows(QModelIndex(), 0, 0);
-  chats.prepend(ptr);
+  chats.prepend(message);
   endInsertRows();
 
   m_count += 1;
@@ -33,16 +35,19 @@ void ChatModel::prependMessage(ChatMessage *message) {
 
 void ChatModel::appendMessage(ChatMessage *message) {
   QSharedPointer<ChatMessage> ptr(message);
+  return this->appendMessage(ptr);
+}
 
+void ChatModel::appendMessage(const QSharedPointer<ChatMessage> &message) {
   const int idx = rowCount();
   if(idx != 0 && !chats.isEmpty()) {
     auto prev = chats.at(idx - 1);
-    prev->next = ptr;
-    ptr->previous = prev;
+    prev->next = message;
+    message->previous = prev;
   }
 
   beginInsertRows(QModelIndex(), idx, rowCount());
-  chats.append(ptr);
+  chats.append(message);
   endInsertRows();
 
   m_count += 1;
@@ -131,7 +136,6 @@ void ChatModel::onProtocolFilter(QString protocol) {
 void ChatModel::onGetOverviewMessages(const int limit, const int offset) {
   this->clear();
 
-#ifdef RTCOM
   rtcom_query* query_struct = rtcomStartQuery(limit, offset, RTCOM_EL_QUERY_GROUP_BY_CONTACT);
   bool query_prepared = FALSE;
 
@@ -159,7 +163,6 @@ void ChatModel::onGetOverviewMessages(const int limit, const int offset) {
   auto results = rtcomIterateResults(query_struct);
   for (const auto &message: results)
     this->appendMessage(message);
-#endif
 }
 
 unsigned int ChatModel::getMessages(const QString &service_id, const QString &remote_uid) {

--- a/src/models/ChatModel.h
+++ b/src/models/ChatModel.h
@@ -38,7 +38,9 @@ public:
     }
 
     void prependMessage(ChatMessage *message);
+    void prependMessage(const QSharedPointer<ChatMessage> &message);
     void appendMessage(ChatMessage *message);
+    void appendMessage(const QSharedPointer<ChatMessage> &message);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -61,6 +61,12 @@ Settings::Settings(Conversations *ctx, QWidget *parent) :
     config()->set(ConfigKeys::EnterKeySendsChat, toggled);
   });
 
+  // Enable notifications
+  ui->checkBox_enableNotifications->setChecked(config()->get(ConfigKeys::EnableNotifications).toBool());
+  connect(ui->checkBox_enableNotifications, &QCheckBox::toggled, [](bool toggled){
+    config()->set(ConfigKeys::EnableNotifications, toggled);
+  });
+
   // text scaling
   float textScaling = config()->get(ConfigKeys::TextScaling).toFloat();
   if(textScaling < 1) textScaling = 1;

--- a/src/settings.ui
+++ b/src/settings.ui
@@ -229,6 +229,20 @@
          </widget>
         </item>
         <item>
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Incoming message notifications</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="checkBox_enableNotifications">
+          <property name="text">
+           <string>Enabled</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="verticalSpacer_2">
           <property name="orientation">
            <enum>Qt::Vertical</enum>


### PR DESCRIPTION
- Uses `/velnias75/libnotify-qt`, modified/updated to work on Leste
- Notifications are active when the app is in the background
- Prevents notification spam; one notification per individual sender is issued
- Clicking on a notification opens the relevant chat window
- Dismissing a notification does nothing
- Optionally disable notifications via settings